### PR TITLE
automatically select AMI for the intance type architecture

### DIFF
--- a/bastion/ami.go
+++ b/bastion/ami.go
@@ -46,7 +46,6 @@ func GetAndValidateAmi(sess *session.Session, input string, instance_type string
 		}
 		return ami, nil
 	}
-	print("THISFHOSD")
 	return "", errors.New("unable to find ami")
 }
 

--- a/bastion/launch.go
+++ b/bastion/launch.go
@@ -44,6 +44,8 @@ func CmdLaunchLinuxBastion(c *cli.Context) error {
 		return err
 	}
 
+	instanceType = c.String("instance-type")
+
 	instanceProfile, err = GetIAMInstanceProfile(sess)
 	if err != nil {
 		return err
@@ -160,7 +162,6 @@ func CmdLaunchWindowsBastion(c *cli.Context) error {
 
 	id = GenerateSessionId()
 	log.Println("bastion session id: " + id)
-	log.Println(c.String("instance-type"))
 
 	sess = SetupAWSSession(c.String("region"), c.String("profile"))
 
@@ -168,7 +169,6 @@ func CmdLaunchWindowsBastion(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	log.Println(c.String("instance-type"))
 
 	instanceProfile, err = GetIAMInstanceProfile(sess)
 	if err != nil {

--- a/bastion/launch.go
+++ b/bastion/launch.go
@@ -39,7 +39,7 @@ func CmdLaunchLinuxBastion(c *cli.Context) error {
 
 	sess = SetupAWSSession(c.String("region"), c.String("profile"))
 
-	ami, err = GetAndValidateAmi(sess, c.String("ami"))
+	ami, err = GetAndValidateAmi(sess, c.String("ami"), c.String("instance-type"))
 	if err != nil {
 		return err
 	}
@@ -98,8 +98,6 @@ func CmdLaunchLinuxBastion(c *cli.Context) error {
 		securitygroup := SelectSecurityGroup(securitygroups)
 		securitygroupId = securitygroup.SecurityGrouId
 	}
-
-	instanceType = c.String("instance-type")
 
 	userdata = BuildLinuxUserdata(sshKey, c.String("ssh-user"), expire, expireAfter, c.String("efs"), c.String("access-points"))
 
@@ -162,13 +160,15 @@ func CmdLaunchWindowsBastion(c *cli.Context) error {
 
 	id = GenerateSessionId()
 	log.Println("bastion session id: " + id)
+	log.Println(c.String("instance-type"))
 
 	sess = SetupAWSSession(c.String("region"), c.String("profile"))
 
-	ami, err = GetAndValidateAmi(sess, c.String("ami"))
+	ami, err = GetAndValidateAmi(sess, c.String("ami"), c.String("instance-type"))
 	if err != nil {
 		return err
 	}
+	log.Println(c.String("instance-type"))
 
 	instanceProfile, err = GetIAMInstanceProfile(sess)
 	if err != nil {


### PR DESCRIPTION
## Added support for dynamic selection of architecture based on selected instance type

User is now prompted to select the service they would like to retrieve their AMI from based on those the chosen instance type supports.

---
### x86_64 example
1) User initiates a bastion launch with selected instance type of "c3.large", the user is then given the option to select the supported architectures for the instance type.
<img width="886" alt="Screen Shot 2022-09-02 at 3 26 17 pm" src="https://user-images.githubusercontent.com/64295670/188065026-2ee08823-3879-45e7-9426-c43bb2a2d5d3.png">
2) The user selects 'x86_64', they then choose the service where they want to pull the AMI from.
<img width="877" alt="Screen Shot 2022-09-02 at 3 28 52 pm" src="https://user-images.githubusercontent.com/64295670/188065322-b89828b1-28ee-454b-b3b5-99c8ec5feb9f.png">
3) Finally, they select the AMI they would like to launch the bastion with, then continue on the with the normal workflow.
<img width="886" alt="Screen Shot 2022-09-02 at 3 29 51 pm" src="https://user-images.githubusercontent.com/64295670/188065435-27a70671-ae45-4d78-b6cc-68bc684c56d8.png">
4) The bastion is launched with the selected AMI type.
<p float="left">
  <img src="https://user-images.githubusercontent.com/64295670/188065599-25f20fdf-650d-4477-aeeb-7b5c694b2b6f.png" width="400" />
  <img src="https://user-images.githubusercontent.com/64295670/188065720-1bb8d79a-0c06-43a4-84bf-cb1c9fea060b.png" width="400" /> 
</p>

---
### arm64 example
1) Instance type supplied is 'c6g.large' which only supports arm64
<img width="891" alt="Screen Shot 2022-09-02 at 3 36 47 pm" src="https://user-images.githubusercontent.com/64295670/188066171-db4079ca-192e-4456-ab19-8e00b4c046ee.png">
2) We select our chosen AMI from our selected service.
<img width="888" alt="Screen Shot 2022-09-02 at 3 37 46 pm" src="https://user-images.githubusercontent.com/64295670/188066277-a90d7f8d-70e6-4a59-ae0f-8079032801d4.png">
3) The bastion is launches with the AMI using the selected architecture type
<p float="left">
  <img src="https://user-images.githubusercontent.com/64295670/188066472-221fd633-219b-4350-bcb0-6ef68a160a5d.png" width="400" />
  <img src="https://user-images.githubusercontent.com/64295670/188066545-2b35d56b-dd66-4e9c-b37d-96aac0511df7.png" width="400" /> 
</p>

