### PR TITLE
associate public ip address to an instance

### DIFF
--- a/bastion/launch.go
+++ b/bastion/launch.go
@@ -74,6 +74,7 @@ func CreateBastion(c *cli.Context) (string, string, error) {
 		keyName           string
 		userdata          string
 		spot              bool
+		publicIpAddress   bool
 		bastionInstanceId string
 	)
 	//Check if theres a better way to create a default instance? eg: call CmdLaunchLinuxBastion with some spoofed cli context? but somehow return instance id
@@ -118,6 +119,11 @@ func CreateBastion(c *cli.Context) (string, string, error) {
 		spot = false
 	}
 
+	publicIpAddress = true
+	if c.Bool("private") {
+		publicIpAddress = false
+	}
+
 	subnetId = c.String("subnet-id")
 	if subnetId == "" {
 		subnets, err := GetSubnets(sess)
@@ -147,7 +153,7 @@ func CreateBastion(c *cli.Context) (string, string, error) {
 
 	userdata = BuildLinuxUserdata(sshKey, c.String("ssh-user"), expire, expireAfter, c.String("efs"), c.String("access-points"))
 
-	bastionInstanceId, err = StartEc2(id, sess, ami, instanceProfile, subnetId, securitygroupId, instanceType, launchedBy, userdata, keyName, spot)
+	bastionInstanceId, err = StartEc2(id, sess, ami, instanceProfile, subnetId, securitygroupId, instanceType, launchedBy, userdata, keyName, spot, publicIpAddress)
 	if err != nil {
 		return "", "", err
 	}
@@ -170,6 +176,7 @@ func CmdLaunchWindowsBastion(c *cli.Context) error {
 		keyName           string
 		userdata          string
 		spot              bool
+		publicIpAddress   bool
 		bastionInstanceId string
 	)
 
@@ -196,6 +203,11 @@ func CmdLaunchWindowsBastion(c *cli.Context) error {
 	spot = true
 	if c.Bool("no-spot") {
 		spot = false
+	}
+
+	publicIpAddress = true
+	if c.Bool("private") {
+		publicIpAddress = false
 	}
 
 	subnetId = c.String("subnet-id")
@@ -245,7 +257,7 @@ func CmdLaunchWindowsBastion(c *cli.Context) error {
 
 	userdata = BuildWindowsUserdata()
 
-	bastionInstanceId, err = StartEc2(id, sess, ami, instanceProfile, subnetId, securitygroupId, instanceType, launchedBy, userdata, keyName, spot)
+	bastionInstanceId, err = StartEc2(id, sess, ami, instanceProfile, subnetId, securitygroupId, instanceType, launchedBy, userdata, keyName, spot, publicIpAddress)
 	if err != nil {
 		return err
 	}

--- a/entrypoint/main.go
+++ b/entrypoint/main.go
@@ -59,6 +59,10 @@ func CliMain() {
 						Name:  "no-spot",
 						Usage: "set to use on-demand EC2 pricing",
 					},
+					&cli.BoolFlag{
+						Name:  "private",
+						Usage: "don't attach a public IP to the bastion",
+					},
 					&cli.StringFlag{
 						Name:  "efs",
 						Usage: "EFS file system id to mount to the bastion instance",
@@ -152,6 +156,14 @@ func CliMain() {
 					&cli.BoolFlag{
 						Name:  "no-terminate",
 						Usage: "disable automatic termination of the bastion instance when the session disconnects",
+					},
+					&cli.BoolFlag{
+						Name:  "no-spot",
+						Usage: "set to use on-demand EC2 pricing",
+					},
+					&cli.BoolFlag{
+						Name:  "private",
+						Usage: "don't attach a public IP to the bastion",
 					},
 				},
 			},
@@ -258,6 +270,10 @@ func CliMain() {
 					&cli.BoolFlag{
 						Name:  "no-spot",
 						Usage: "set to use on-demand EC2 pricing",
+					},
+					&cli.BoolFlag{
+						Name:  "private",
+						Usage: "don't attach a public IP to the bastion",
 					},
 					&cli.IntFlag{
 						Name:    "expire-after",


### PR DESCRIPTION
This resolves the issue where a bastion is launched in a public subnet but the subnet doesn't have the property `associate public ip address` enabled. 

this can be disabled with the `--private` flag when launching a bastion if you want to launch one in a private subnet using AWS service endpoints to connect to it over ssm sessions manager.